### PR TITLE
Here's a revised version of the message:

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ A simple web application for practicing word dictation in multiple languages (En
     *   Open the `index.html` file in a modern web browser that supports the Web Speech API (e.g., Chrome, Firefox, Edge, Safari).
 
 2.  **Using the App:**
-    *   When the page loads, the first word/sentence will be displayed and spoken automatically.
-    *   Click the "Play" button to hear the current word/sentence again.
+    *   When the page loads, the first word/sentence will be displayed. Audio playback requires an initial click on the 'Play' button; a prompt will guide you.
+    *   Click the "Play" button to hear the current word/sentence again. (This will also enable audio if it's the first time).
     *   Type what you hear into the input field.
     *   Click the "Check" button or press Enter to see if your answer is correct. Feedback will appear below the input field.
     *   Click the "Next" button to move to the next word/sentence. This will also be spoken automatically.


### PR DESCRIPTION
fix: Refine audio activation to be more synchronous

I've further refined the audio enabling mechanism to address potential "not-allowed" errors:

- On your first click of the "Play" button:
    - Audio is enabled (`audioEnabled = true`).
    - Any queued speech is cancelled.
    - I'll speak a very short, low-volume "priming" utterance synchronously.
    - Then, I'll immediately and synchronously call the main function to speak the actual word (`speak()`).
- Subsequent clicks on "Play" will also cancel any ongoing speech before speaking.
- The `speak()` function itself also cancels ongoing speech before playing.

This ensures that both the priming sound and the first intended word playback are initiated directly and synchronously within your click event, which is critical for satisfying stricter browser autoplay/interaction policies.