### PR TITLE
feat: Implement word list management with Local Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ A simple web application for practicing word dictation in multiple languages (En
     *   "Next" button to move to the next word/sentence.
 *   **User-Friendly Interface:** Basic styling for ease of use.
 *   **Phonetic Display:** Shows IPA phonetic transcriptions for English words and sentences to aid in pronunciation.
+*   **Word List Management (via Local Storage):**
+    *   Add custom words (English with optional IPA, Chinese).
+    *   Delete words from the list.
+    *   Your custom word list is saved in your browser's Local Storage and persists across sessions on the same browser.
+    *   Toggle the management interface with the "Manage Words" button.
 
 ## How to Use
 
@@ -28,6 +33,7 @@ A simple web application for practicing word dictation in multiple languages (En
     *   Type what you hear into the input field.
     *   Click the "Check" button or press Enter to see if your answer is correct. Feedback will appear below the input field.
     *   Click the "Next" button to move to the next word/sentence. This will also be spoken automatically.
+    *   Click the "Manage Words" button to open the word list management panel. Here you can add new words or delete existing ones from your personalized list.
 
 ## Files
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,40 @@
         <input type="text" id="user-input">
         <button id="check-button">Check</button>
         <div id="feedback-area"></div>
+
+        <hr style="margin: 20px 0;"> <!- Simple separator -->
+        <button id="toggle-manage-button">Manage Words</button>
+
+        <div id="manage-words-section" class="hidden">
+            <h2>Manage Words</h2>
+
+            <form id="add-word-form">
+                <h3>Add New Word</h3>
+                <div>
+                    <label for="manage-word-text">Text:</label>
+                    <input type="text" id="manage-word-text" required>
+                </div>
+                <div>
+                    <label for="manage-word-lang">Language:</label>
+                    <select id="manage-word-lang">
+                        <option value="en-US">English (US)</option>
+                        <option value="zh-CN">Chinese (CN)</option>
+                    </select>
+                </div>
+                <div id="phonetic-input-container"> <!-- Container for phonetic input, to be shown/hidden -->
+                    <label for="manage-word-phonetic">Phonetic (IPA):</label>
+                    <input type="text" id="manage-word-phonetic">
+                </div>
+                <button type="submit">Add Word</button>
+            </form>
+
+            <h3>Current Word List</h3>
+            <div style="max-height: 200px; overflow-y: auto; border: 1px solid #eee; padding: 10px; margin-top:10px;">
+                <ul id="word-list-ul">
+                    <!-- Words will be listed here by JavaScript -->
+                </ul>
+            </div>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,26 +1,72 @@
-// Word List
-const words = [
-    // English Words
+// 1. Define Local Storage Key
+const WORDS_STORAGE_KEY = 'wordBroadcastingAppWords';
+
+// 2. saveWordsToLocalStorage(wordsArray) function
+function saveWordsToLocalStorage(wordsArray) {
+    try {
+        localStorage.setItem(WORDS_STORAGE_KEY, JSON.stringify(wordsArray));
+        console.log("Words saved to Local Storage.");
+    } catch (e) {
+        console.error("Error saving words to Local Storage:", e);
+        if (feedbackArea) {
+            feedbackArea.textContent = "Error saving word list. Settings might not persist.";
+        }
+    }
+}
+
+// 3. loadWordsFromLocalStorage() function
+function loadWordsFromLocalStorage() {
+    try {
+        const storedWords = localStorage.getItem(WORDS_STORAGE_KEY);
+        if (storedWords) {
+            const parsedWords = JSON.parse(storedWords);
+            if (Array.isArray(parsedWords)) {
+                if (parsedWords.length > 0 && parsedWords[0].text && parsedWords[0].lang) {
+                    return parsedWords;
+                } else if (parsedWords.length === 0) {
+                    return parsedWords;
+                }
+            }
+        }
+    } catch (e) {
+        console.error("Error loading or parsing words from Local Storage:", e);
+    }
+    return null;
+}
+
+// 4. Integrate into Script Startup
+let words = [];
+
+const defaultWords = [
     { text: 'apple', lang: 'en-US', phonetic: '/ˈæpəl/' },
     { text: 'house', lang: 'en-US', phonetic: '/haʊs/' },
     { text: 'computer', lang: 'en-US', phonetic: '/kəmˈpjuːtər/' },
     { text: 'book', lang: 'en-US', phonetic: '/bʊk/' },
     { text: 'water', lang: 'en-US', phonetic: '/ˈwɔːtər/' },
-    // Chinese Words
-    { text: '你好', lang: 'zh-CN' }, // nǐ hǎo (hello)
-    { text: '谢谢', lang: 'zh-CN' }, // xièxie (thank you)
-    { text: '学习', lang: 'zh-CN' }, // xuéxí (study/learn)
-    { text: '朋友', lang: 'zh-CN' }, // péngyou (friend)
-    { text: '快乐', lang: 'zh-CN' }, // kuàilè (happy)
-    // English Sentences
+    { text: '你好', lang: 'zh-CN' },
+    { text: '谢谢', lang: 'zh-CN' },
+    { text: '学习', lang: 'zh-CN' },
+    { text: '朋友', lang: 'zh-CN' },
+    { text: '快乐', lang: 'zh-CN' },
     { text: 'Good morning, how are you?', lang: 'en-US', phonetic: '/ɡʊd ˈmɔːrnɪŋ, haʊ ɑːr juː?/' },
     { text: 'Practice makes perfect.', lang: 'en-US', phonetic: '/ˈpræktɪs meɪks ˈpɜːrfɪkt/' },
-    // Chinese Sentences
-    { text: '今天天气很好。', lang: 'zh-CN' }, // Jīntiān tiānqì hěn hǎo. (The weather is very good today.)
-    { text: '我喜欢学习语言。', lang: 'zh-CN' }  // Wǒ xǐhuān xuéxí yǔyán. (I like learning languages.)
+    { text: '今天天气很好。', lang: 'zh-CN' },
+    { text: '我喜欢学习语言。', lang: 'zh-CN' }
 ];
 
-// Variables
+let loadedWords = loadWordsFromLocalStorage();
+
+if (loadedWords && Array.isArray(loadedWords) && loadedWords.length > 0) {
+    words = loadedWords;
+    console.log("Words loaded from Local Storage.");
+} else {
+    words = defaultWords;
+    console.log("Using default words. Saving to Local Storage.");
+    saveWordsToLocalStorage(words);
+}
+
+
+// Variables for dictation UI
 let currentWordIndex = -1;
 const wordDisplay = document.getElementById('word-display');
 const playButton = document.getElementById('play-button');
@@ -28,11 +74,197 @@ const nextButton = document.getElementById('next-button');
 const userInput = document.getElementById('user-input');
 const checkButton = document.getElementById('check-button');
 const feedbackArea = document.getElementById('feedback-area');
-const phoneticDisplay = document.getElementById('phonetic-display'); // 1. Get DOM reference
+const phoneticDisplay = document.getElementById('phonetic-display');
 
 let audioEnabled = false;
 
-// speak() function
+// DOM References for Management UI
+const manageWordText = document.getElementById('manage-word-text');
+const manageWordLang = document.getElementById('manage-word-lang');
+const manageWordPhonetic = document.getElementById('manage-word-phonetic');
+const phoneticInputContainer = document.getElementById('phonetic-input-container');
+const addWordForm = document.getElementById('add-word-form');
+const wordListUl = document.getElementById('word-list-ul');
+// 1. Get DOM References for toggle functionality
+const toggleManageButton = document.getElementById('toggle-manage-button');
+const manageWordsSection = document.getElementById('manage-words-section');
+
+
+// renderWordList() Function
+function renderWordList() {
+    if (!wordListUl) return;
+    wordListUl.innerHTML = '';
+
+    if (!words || words.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'No words in the list. Add some above!';
+        wordListUl.appendChild(li);
+        return;
+    }
+
+    words.forEach((word, index) => {
+        const li = document.createElement('li');
+        let content = `${index + 1}. ${word.text} (${word.lang})`;
+        if (word.phonetic) {
+            content += ` [${word.phonetic}]`;
+        }
+
+        const textNode = document.createTextNode(content + " ");
+        li.appendChild(textNode);
+
+        const deleteButton = document.createElement('button');
+        deleteButton.textContent = 'Delete';
+        deleteButton.classList.add('delete-word-btn');
+        deleteButton.setAttribute('data-index', index);
+
+        deleteButton.addEventListener('click', function() {
+            const wordIndexToDelete = parseInt(this.getAttribute('data-index'), 10);
+
+            // Optional: Add a confirmation dialog
+            // if (!confirm(`Are you sure you want to delete "${words[wordIndexToDelete].text}"?`)) {
+            //     return;
+            // }
+
+            if (!isNaN(wordIndexToDelete) && wordIndexToDelete >= 0 && wordIndexToDelete < words.length) {
+                const deletedWordText = words[wordIndexToDelete].text;
+                words.splice(wordIndexToDelete, 1);
+                saveWordsToLocalStorage(words);
+                renderWordList();
+
+                console.log(`Deleted word: "${deletedWordText}" at index ${wordIndexToDelete}`);
+
+                if (words.length === 0) {
+                    currentWordIndex = -1;
+                    if (wordDisplay) wordDisplay.textContent = "Word list empty.";
+                    if (phoneticDisplay) phoneticDisplay.textContent = "";
+                    if (feedbackArea) feedbackArea.textContent = "All words deleted. Add some words.";
+                    if ('speechSynthesis' in window) window.speechSynthesis.cancel();
+                } else {
+                    if (currentWordIndex > wordIndexToDelete) {
+                        currentWordIndex--;
+                    }
+                    if (currentWordIndex >= words.length) {
+                         currentWordIndex = words.length -1;
+                    }
+                    if (currentWordIndex < 0 && words.length > 0) {
+                        currentWordIndex = 0;
+                    }
+
+                    if (currentWordIndex !== -1 && words[currentWordIndex]) {
+                        const currentWordObject = words[currentWordIndex];
+                        if (wordDisplay) wordDisplay.textContent = currentWordObject.text;
+                        if (phoneticDisplay) {
+                            if (currentWordObject.lang && currentWordObject.lang.startsWith('en') && currentWordObject.phonetic) {
+                                phoneticDisplay.textContent = currentWordObject.phonetic;
+                            } else {
+                                phoneticDisplay.textContent = '';
+                            }
+                        }
+                    } else if (words.length > 0 && currentWordIndex === -1) {
+                        currentWordIndex = 0;
+                        const currentWordObject = words[currentWordIndex];
+                        if (wordDisplay) wordDisplay.textContent = currentWordObject.text;
+                        if (phoneticDisplay) {
+                             if (currentWordObject.lang && currentWordObject.lang.startsWith('en') && currentWordObject.phonetic) {
+                                phoneticDisplay.textContent = currentWordObject.phonetic;
+                            } else {
+                                phoneticDisplay.textContent = '';
+                            }
+                        }
+                    }
+                }
+                if(feedbackArea && (feedbackArea.textContent.includes("Correct!") || feedbackArea.textContent.includes("Incorrect"))){
+                    feedbackArea.textContent = "";
+                }
+            } else {
+                console.error("Invalid index for delete:", wordIndexToDelete);
+            }
+        });
+
+        li.appendChild(deleteButton);
+        wordListUl.appendChild(li);
+    });
+}
+
+
+// Toggle Phonetic Input Visibility
+if (manageWordLang && phoneticInputContainer) {
+    manageWordLang.addEventListener('change', () => {
+        if (manageWordLang.value.startsWith('en')) {
+            phoneticInputContainer.style.display = '';
+        } else {
+            phoneticInputContainer.style.display = 'none';
+        }
+    });
+    manageWordLang.dispatchEvent(new Event('change'));
+}
+
+// Handle "Add Word" Form Submission
+if (addWordForm) {
+    addWordForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+
+        if (!manageWordText || !manageWordLang || !manageWordPhonetic) {
+            console.error("Form input elements not found for adding word.");
+            return;
+        }
+
+        const text = manageWordText.value.trim();
+        const lang = manageWordLang.value;
+        const phoneticValue = manageWordPhonetic.value.trim();
+
+        if (!text) {
+            alert('Word text cannot be empty.');
+            manageWordText.focus();
+            return;
+        }
+
+        const newWord = { text, lang };
+        if (lang.startsWith('en') && phoneticValue) {
+            newWord.phonetic = phoneticValue;
+        }
+
+        words.push(newWord);
+        saveWordsToLocalStorage(words);
+        renderWordList();
+
+        if (words.length === 1) {
+            currentWordIndex = 0;
+            const currentWordObject = words[currentWordIndex];
+            if (wordDisplay) wordDisplay.textContent = currentWordObject.text;
+            if (phoneticDisplay) {
+                 if (currentWordObject.lang && currentWordObject.lang.startsWith('en') && currentWordObject.phonetic) {
+                    phoneticDisplay.textContent = currentWordObject.phonetic;
+                } else {
+                    phoneticDisplay.textContent = '';
+                }
+            }
+            if (feedbackArea) feedbackArea.textContent = "";
+        }
+
+        manageWordText.value = '';
+        if (manageWordLang.value.startsWith('en')) {
+           manageWordPhonetic.value = '';
+        }
+        manageWordText.focus();
+    });
+}
+
+// 2. Add Event Listener to toggleManageButton
+if (toggleManageButton && manageWordsSection) {
+    toggleManageButton.addEventListener('click', () => {
+        manageWordsSection.classList.toggle('hidden');
+        if (manageWordsSection.classList.contains('hidden')) {
+            toggleManageButton.textContent = 'Manage Words';
+        } else {
+            toggleManageButton.textContent = 'Hide Management';
+            renderWordList(); // Re-render the list when shown
+        }
+    });
+}
+
+
+// --- Core Dictation App Functions ---
 function speak() {
     if (!audioEnabled) {
         if (feedbackArea) {
@@ -52,19 +284,30 @@ function speak() {
         return;
     }
 
-    if (currentWordIndex < 0 || currentWordIndex >= words.length) {
-        console.warn("Invalid currentWordIndex for speak():", currentWordIndex);
-        if (feedbackArea) {
-            feedbackArea.textContent = "No word selected to play.";
-        }
+    if (words.length === 0) {
+        if (feedbackArea) feedbackArea.textContent = "No words to speak. Word list is empty.";
+        console.warn("Speak called with empty words array.");
         return;
+    }
+    if (currentWordIndex < 0 || currentWordIndex >= words.length) {
+        console.warn("Invalid currentWordIndex for speak():", currentWordIndex, "Words length:", words.length);
+        if (words.length > 0) {
+            currentWordIndex = 0;
+             console.log("Attempted to reset currentWordIndex. Click Next or Play to re-sync display.");
+        } else {
+            if (feedbackArea) feedbackArea.textContent = "No word selected to play.";
+            return;
+        }
     }
 
     const currentWord = words[currentWordIndex];
+     if (!currentWord) {
+        console.error("currentWord is undefined at index:", currentWordIndex);
+        if (feedbackArea) feedbackArea.textContent = "Error: Could not find word data.";
+        return;
+    }
 
     try {
-        // Cancel any speech that might be ongoing from a previous rapid click,
-        // especially if the priming utterance was very short or didn't play.
         window.speechSynthesis.cancel();
         const utterance = new SpeechSynthesisUtterance(currentWord.text);
         utterance.lang = currentWord.lang;
@@ -102,21 +345,37 @@ function speak() {
     }
 }
 
-// displayNextWord() function
 function displayNextWord() {
+    if (words.length === 0) {
+        if (wordDisplay) wordDisplay.textContent = "No words in list.";
+        if (phoneticDisplay) phoneticDisplay.textContent = "";
+        if (userInput) userInput.value = "";
+        if (feedbackArea) feedbackArea.textContent = "The word list is empty.";
+        currentWordIndex = -1;
+        if ('speechSynthesis' in window) window.speechSynthesis.cancel();
+        return;
+    }
+
     currentWordIndex++;
     if (currentWordIndex >= words.length) {
-        currentWordIndex = 0; // Loop through words
+        currentWordIndex = 0;
     }
     const currentWordObject = words[currentWordIndex];
+
+    if (!currentWordObject) {
+        console.error("currentWordObject is undefined in displayNextWord at index:", currentWordIndex);
+        if (wordDisplay) wordDisplay.textContent = "Error loading word.";
+        if (phoneticDisplay) phoneticDisplay.textContent = "";
+        return;
+    }
+
     if (wordDisplay) wordDisplay.textContent = currentWordObject.text;
 
-    // 2. Update displayNextWord() function
-    if (phoneticDisplay) { // Check if the element exists
+    if (phoneticDisplay) {
         if (currentWordObject.lang && currentWordObject.lang.startsWith('en') && currentWordObject.phonetic) {
             phoneticDisplay.textContent = currentWordObject.phonetic;
         } else {
-            phoneticDisplay.textContent = ''; // Clear for non-English words or if no phonetic info
+            phoneticDisplay.textContent = '';
         }
     }
 
@@ -132,20 +391,24 @@ function displayNextWord() {
     speak();
 }
 
-// checkUserInput() function
 function checkUserInput() {
-    if (currentWordIndex < 0 || currentWordIndex >= words.length) {
-        if (feedbackArea) feedbackArea.textContent = "No word selected to check.";
+    if (words.length === 0 || currentWordIndex < 0 || currentWordIndex >= words.length) {
+        if (feedbackArea) feedbackArea.textContent = "No word selected to check, or word list is empty.";
         return;
     }
 
     const currentWordObject = words[currentWordIndex];
+    if (!currentWordObject) {
+        console.error("currentWordObject is undefined in checkUserInput at index:", currentWordIndex);
+        if (feedbackArea) feedbackArea.textContent = "Error: Could not find word data for checking.";
+        return;
+    }
     const correctAnswer = currentWordObject.text;
     const userAnswer = userInput.value.trim();
 
     let isCorrect = false;
 
-    if (currentWordObject.lang.startsWith('en')) {
+    if (currentWordObject.lang && currentWordObject.lang.startsWith('en')) {
         isCorrect = userAnswer.toLowerCase() === correctAnswer.toLowerCase();
     } else {
         isCorrect = userAnswer === correctAnswer;
@@ -165,7 +428,7 @@ function checkUserInput() {
 }
 
 
-// Event Listeners
+// Event Listeners for dictation UI
 if (nextButton) {
     nextButton.addEventListener('click', displayNextWord);
 }
@@ -176,7 +439,6 @@ if (playButton) {
             audioEnabled = true;
             if (feedbackArea) {
                 const currentFeedback = feedbackArea.textContent || "";
-                // Clear the "Click 'Play' to enable audio." or similar messages
                 if (currentFeedback.startsWith("Click 'Play' to enable audio.") || currentFeedback.startsWith("Audio not enabled.")) {
                     feedbackArea.textContent = "";
                 }
@@ -184,26 +446,20 @@ if (playButton) {
 
             if ('speechSynthesis' in window) {
                 try {
-                    // Cancel any existing speech *before* the priming utterance.
-                    // This is important if the user clicks rapidly.
                     window.speechSynthesis.cancel();
                     const primeUtterance = new SpeechSynthesisUtterance(" ");
                     primeUtterance.volume = 0.01;
                     primeUtterance.pitch = 0.5;
                     primeUtterance.rate = 0.5;
                     primeUtterance.lang = 'en-US';
-                    // Remove any onend/onerror handlers from primeUtterance that call the main speak().
                     speechSynthesis.speak(primeUtterance);
                     console.log("Priming utterance attempted synchronously.");
                 } catch (e) {
                     console.error("Error with priming utterance:", e);
                 }
             }
-            // Call the main speak() function immediately and synchronously after attempting the prime.
             speak();
         } else {
-            // If audio was already enabled, just call speak.
-            // Ensure any previous utterance is cancelled before speaking again if user clicks rapidly.
             if ('speechSynthesis' in window) {
                 window.speechSynthesis.cancel();
             }
@@ -229,11 +485,12 @@ function initializeApp() {
     if (words.length > 0) {
         displayNextWord();
     } else {
-        if (wordDisplay) {
-            wordDisplay.textContent = "No words loaded.";
-        }
-        console.warn("Word list is empty. Cannot display initial word.");
+        if (wordDisplay) wordDisplay.textContent = "No words loaded.";
+        if (phoneticDisplay) phoneticDisplay.textContent = "";
+        if (feedbackArea) feedbackArea.textContent = "Word list is empty. Add some words via 'Manage Words'.";
+        console.warn("Word list is empty at initialization.");
     }
+    renderWordList();
 }
 
 if ('speechSynthesis' in window) {

--- a/style.css
+++ b/style.css
@@ -3,13 +3,13 @@ body {
     font-family: 'Helvetica Neue', Arial, sans-serif;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start; /* Changed from center to allow scrolling for long content */
     align-items: center;
     min-height: 100vh;
-    background-color: #f4f7f6; /* Light background color */
+    background-color: #f4f7f6;
     color: #333;
     margin: 0;
-    padding: 10px; /* Add some padding for smaller screens */
+    padding: 20px; /* Increased body padding */
     box-sizing: border-box;
 }
 
@@ -20,74 +20,74 @@ body {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
     text-align: center;
     width: 100%;
-    max-width: 500px; /* Max width for the container */
+    max-width: 600px; /* Slightly increased max-width for management UI */
+    margin-bottom: 20px; /* Added margin at the bottom of container */
 }
 
 /* 2. Heading (h1) */
 h1 {
     color: #2c3e50;
-    margin-bottom: 25px; /* More margin at the bottom */
-    font-size: 2em; /* Responsive font size */
+    margin-bottom: 25px;
+    font-size: 2em;
     text-align: center;
 }
 
 /* 3. Word Display Area (#word-display) */
 #word-display {
-    font-size: 28px; /* Larger font size */
+    font-size: 28px;
     font-weight: bold;
-    color: #3498db; /* A distinct color for the word */
-    margin: 20px 0 5px 0; /* Reduced bottom margin to make space for phonetic display */
+    color: #3498db;
+    margin: 20px 0 5px 0;
     padding: 15px;
     border: 1px solid #e0e0e0;
     border-radius: 6px;
-    min-height: 60px; /* Ensure enough height, considering padding */
+    min-height: 60px;
     display: flex;
     justify-content: center;
     align-items: center;
-    line-height: 1.4; /* Improve readability for sentences */
+    line-height: 1.4;
 }
 
 /* Styling for Phonetic Display Area */
 #phonetic-display {
-    font-size: 1.1em;  /* Relative to body/container font. #word-display is 28px, this will be smaller. */
-    color: #555;       /* Gray color */
+    font-size: 1.1em;
+    color: #555;
     font-style: italic;
-    margin-top: 0px;   /* Top margin from #word-display */
-    margin-bottom: 15px; /* Bottom margin before buttons */
-    min-height: 1.5em;  /* To prevent layout jumps, accommodates text size */
+    margin-top: 0px;
+    margin-bottom: 15px;
+    min-height: 1.5em;
     text-align: center;
-    display: flex;      /* For vertical centering if needed, matches word-display */
+    display: flex;
     justify-content: center;
     align-items: center;
     line-height: 1.4;
 }
 
 
-/* 4. Buttons (button) */
+/* 4. Buttons (button) - General app buttons */
 button {
     background-color: #3498db;
     color: white;
     border: none;
-    padding: 12px 18px; /* More padding */
+    padding: 12px 18px;
     border-radius: 5px;
     cursor: pointer;
-    margin: 8px 5px; /* Margin between buttons and other elements */
+    margin: 8px 5px;
     font-size: 16px;
-    transition: background-color 0.2s ease, transform 0.1s ease; /* Smooth transitions */
+    transition: background-color 0.2s ease, transform 0.1s ease;
 }
 
 button:hover {
-    background-color: #2980b9; /* Darker shade on hover */
+    background-color: #2980b9;
 }
 
 button:active {
-    background-color: #2471a3; /* Even darker on active/click */
-    transform: scale(0.98); /* Slight press effect */
+    background-color: #2471a3;
+    transform: scale(0.98);
 }
 
-/* Styling for specific buttons if needed, e.g., a 'next' button */
 #next-button {
-    background-color: #2ecc71; /* Green for 'Next' */
+    background-color: #2ecc71;
 }
 
 #next-button:hover {
@@ -104,9 +104,9 @@ button:active {
     padding: 12px;
     border: 1px solid #ccc;
     border-radius: 5px;
-    margin: 15px 0; /* Margin top and bottom */
-    width: calc(100% - 26px); /* Adjust for padding and border */
-    box-sizing: border-box; /* Include padding and border in the element's total width and height */
+    margin: 15px 0;
+    width: calc(100% - 26px);
+    box-sizing: border-box;
     font-size: 16px;
 }
 
@@ -115,20 +115,150 @@ button:active {
     margin-top: 20px;
     font-size: 18px;
     font-weight: 500;
-    min-height: 30px; /* Ensure enough height */
+    min-height: 30px;
     display: flex;
     justify-content: center;
     align-items: center;
     padding: 5px;
-    color: #555; /* Default text color */
+    color: #555;
     line-height: 1.5;
 }
 
-/* Responsive adjustments (optional, but good practice) */
+/* --- Word Management UI Styling --- */
+
+/* 1. .hidden Class */
+.hidden {
+    display: none !important;
+}
+
+/* 2. #manage-words-section Styling */
+#manage-words-section {
+    margin-top: 30px; /* Increased margin for better separation */
+    padding: 20px;    /* Increased padding */
+    border: 1px solid #ddd; /* Slightly softer border */
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    text-align: left; /* Align text to left for forms and lists */
+}
+
+#manage-words-section h2,
+#manage-words-section h3 {
+    text-align: center; /* Center headings within the section */
+    color: #333;
+    margin-bottom: 15px;
+}
+#manage-words-section h3 {
+    margin-top: 20px;
+    font-size: 1.2em;
+}
+
+
+/* 3. Form Elements */
+#add-word-form div {
+    margin-bottom: 12px; /* Slightly more margin */
+    display: flex; /* For better alignment of label and input */
+    flex-wrap: wrap; /* Allow wrapping on small screens */
+    align-items: center;
+}
+#add-word-form label {
+    display: inline-block;
+    width: 130px; /* Adjusted width */
+    margin-right: 10px;
+    font-weight: 500;
+    color: #444;
+}
+#add-word-form input[type="text"],
+#add-word-form select {
+    padding: 10px; /* Increased padding */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    /* flex-grow: 1 allows input to take remaining space */
+    flex-grow: 1;
+    min-width: 150px; /* Prevent input from becoming too small */
+    box-sizing: border-box;
+}
+/* Ensure phonetic input container also uses flex for alignment if needed */
+#phonetic-input-container {
+    /* display: flex; already handled by #add-word-form div */
+    /* align-items: center; */
+}
+
+#add-word-form button[type="submit"] {
+    padding: 10px 20px; /* Adjusted padding */
+    background-color: #28a745; /* Green */
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-top: 10px;
+    display: block; /* Make button block to center it easily */
+    margin-left: auto;
+    margin-right: auto;
+}
+#add-word-form button[type="submit"]:hover {
+    background-color: #218838;
+}
+
+/* 4. Word List */
+/* The div wrapper for ul was added in HTML for scrolling */
+/* #word-list-ul's parent div already has max-height and overflow from HTML step */
+
+#word-list-ul {
+    list-style-type: none;
+    padding-left: 0;
+    /* Removed max-height, overflow, border, padding from here as it's on parent div */
+    background-color: #fff; /* White background for the list itself */
+}
+#word-list-ul li {
+    padding: 10px 8px; /* Increased padding */
+    border-bottom: 1px solid #f0f0f0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95em;
+    color: #333;
+}
+#word-list-ul li:last-child {
+    border-bottom: none;
+}
+.delete-word-btn {
+    padding: 6px 12px; /* Adjusted padding */
+    background-color: #dc3545; /* Red */
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    margin-left: 10px; /* Space from word text */
+}
+.delete-word-btn:hover {
+    background-color: #c82333;
+}
+
+/* 5. Toggle Button (#toggle-manage-button) */
+#toggle-manage-button {
+    padding: 10px 20px; /* Adjusted padding */
+    background-color: #007bff; /* Blue */
+    color: white;
+    border: none;
+    border-radius: 5px; /* Slightly more rounded */
+    cursor: pointer;
+    margin-top: 25px; /* Increased margin */
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    font-size: 1.05em; /* Slightly larger font */
+}
+#toggle-manage-button:hover {
+    background-color: #0056b3;
+}
+
+
+/* Responsive adjustments */
 @media (max-width: 600px) {
     .container {
-        margin: 15px;
-        padding: 20px;
+        margin: 10px; /* Reduced margin for small screens */
+        padding: 15px; /* Reduced padding */
     }
 
     h1 {
@@ -146,7 +276,7 @@ button:active {
         margin-bottom: 10px;
     }
 
-    button {
+    button { /* General buttons */
         padding: 10px 15px;
         font-size: 15px;
     }
@@ -159,5 +289,22 @@ button:active {
     #feedback-area {
         font-size: 17px;
         min-height: 25px;
+    }
+
+    #manage-words-section {
+        padding: 15px;
+    }
+    #add-word-form label {
+        width: 100%; /* Stack label and input on small screens */
+        margin-bottom: 5px;
+        text-align: left;
+    }
+    #add-word-form input[type="text"],
+    #add-word-form select {
+        width: 100%; /* Full width for inputs on small screens */
+    }
+    #toggle-manage-button {
+        font-size: 1em;
+        padding: 10px 15px;
     }
 }


### PR DESCRIPTION
This commit introduces a major feature allowing you to manage the word list for the dictation app.

Key changes:
- Words are now loaded from and saved to the browser's Local Storage. If Local Storage is empty or invalid, a default word list is used and then saved.
- A new "Manage Words" section has been added to the UI:
    - You can view the current list of words.
    - A form allows adding new words (text, language, and optional phonetic IPA for English words).
    - Words can be deleted from the list.
- The management section can be toggled via a "Manage Words" button.
- Implemented HTML structure, JavaScript logic for CRUD operations (Create, Read, Delete) on the word list, and CSS for styling the management UI.
- The main dictation app now uses the potentially customized word list and updates gracefully when words are added or deleted.
- README.md has been updated to describe this new functionality.

This feature allows you to personalize your learning experience by curating your own word lists.