### PR TITLE
fix: Prevent 'Error speaking: canceled' by adjusting cancel logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -308,7 +308,7 @@ function speak() {
     }
 
     try {
-        window.speechSynthesis.cancel();
+        // The window.speechSynthesis.cancel(); line that was here is REMOVED.
         const utterance = new SpeechSynthesisUtterance(currentWord.text);
         utterance.lang = currentWord.lang;
 


### PR DESCRIPTION
Refactors speech synthesis cancellation logic to reduce the likelihood of the "Error speaking: canceled" error.

- Removed `window.speechSynthesis.cancel()` from the beginning of the main `speak()` function.
- Callers of `speak()` (specifically the `playButton` event listener) are now solely responsible for explicitly calling `window.speechSynthesis.cancel()` before initiating a new speech sequence (e.g., playing a new word or replaying the current one).

This change ensures that the `speak()` function doesn't inadvertently cancel an utterance that was just queued by its caller, particularly during the audio priming sequence on the first "Play" click or during rapid subsequent "Play" clicks.